### PR TITLE
FIX: Don’t introduce named args in test arguments

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1054,7 +1054,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $this->fail($e->getMessage());
         }
 
-        $testArguments = array_merge($this->data, $this->dependencyInput);
+        $testArguments = array_values(array_merge($this->data, $this->dependencyInput));
 
         $this->registerMockObjectsFromTestArguments($testArguments);
 


### PR DESCRIPTION
PHP 8 supports named args, but PHPUnit 5.7 does not. In order to get
Consistent behaviour between PHP7 and PHP8, strip the argument names
from dependency arguments and dataProvider arguments.