### PR TITLE
FIX: Allow Sebastian/comparator 2 and 3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "sminnee/phpunit-mock-objects": "^3.4.9",
         "phpspec/prophecy": "^1.6.2",
         "symfony/yaml": "~2.1|~3.0|~4.0",
-        "sebastian/comparator": "^1.2.4",
-        "sebastian/diff": "^1.4.3",
+        "sebastian/comparator": "^3",
+        "sebastian/diff": "^1.4.3 || ^2 || ^3",
         "sebastian/environment": "^1.3.4 || ^2.0",
-        "sebastian/exporter": "~2.0",
+        "sebastian/exporter": "~2.0 || ^3",
         "sebastian/global-state": "^1.1",
-        "sebastian/object-enumerator": "~2.0",
+        "sebastian/object-enumerator": "~2.0 || ^3",
         "sebastian/resource-operations": "~1.0",
         "sebastian/version": "^1.0.6|^2.0.1",
         "myclabs/deep-copy": "~1.3",
@@ -54,9 +54,6 @@
         "phpdocumentor/reflection-docblock": "3.0.2"
     },
     "config": {
-        "platform": {
-            "php": "5.6.0"
-        },
         "optimize-autoloader": true,
         "sort-packages": true
     },


### PR DESCRIPTION
This means that prophecy 0.11 can be installed.

This means that PHP 8 can be supported.