### PR TITLE
Update travis test version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - master
+  - nightly
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Thanks for developing phpunit5.x for php8!

**Update travis test version**
The php:master has not been updated recently.
https://travis-ci.org/github/sminnee/phpunit/jobs/724806189#L226
PHP 8.0.0-dev (cli) (built: Feb 11 2019 07:42:14)

The php:nightly would be better for php8 test.
PHP 8.0.1-dev (cli) (built: Dec  6 2020 06:17:33)

**Fix travis config warnings**
This fixes travis config warnings.
https://travis-ci.org/github/sminnee/phpunit/builds/729253666/config